### PR TITLE
Use OpenAI Responses API with GPT-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,99 @@
-# AIVAN
+# Telegram Legal Bot
+
+Телеграм-бот для предоставления юридических консультаций на основе модели OpenAI GPT.
+
+## Возможности
+
+- Принимает текстовые запросы от пользователей в Telegram.
+- Обеспечивает интеграцию со специально обученной моделью OpenAI GPT.
+- Форматирует ответы с учётом UX/UI требований (эмодзи, выделение, списки).
+- Ограничивает количество запросов от пользователя и показывает индикатор набора текста.
+- Логирует действия и корректно завершается по сигналам остановки.
+
+## Стек
+
+- Python 3.11+
+- [python-telegram-bot](https://docs.python-telegram-bot.org/) v21 (асинхронный API)
+- [OpenAI Python SDK](https://github.com/openai/openai-python) с использованием Responses API и модели `gpt-5`
+- [python-dotenv](https://pypi.org/project/python-dotenv/)
+- Poetry для управления зависимостями и запуском
+
+## Структура проекта
+
+```
+telegram_legal_bot/
+├── main.py
+├── config.py
+├── handlers/
+│   ├── __init__.py
+│   ├── start.py
+│   └── legal_query.py
+├── services/
+│   ├── __init__.py
+│   └── openai_service.py
+├── utils/
+│   ├── __init__.py
+│   ├── message_formatter.py
+│   └── rate_limiter.py
+├── .env.example
+├── requirements.txt
+└── pyproject.toml
+```
+
+## Подготовка окружения
+
+1. Установите Poetry согласно [официальной инструкции](https://python-poetry.org/docs/).
+2. Склонируйте репозиторий и перейдите в корень проекта.
+3. Скопируйте `.env.example` в `.env` и заполните значения переменных:
+
+```env
+TELEGRAM_BOT_TOKEN=ваш_токен
+OPENAI_API_KEY=ваш_api_ключ
+OPENAI_MODEL=gpt-5
+MAX_REQUESTS_PER_HOUR=10
+```
+
+4. Установите зависимости и активируйте виртуальное окружение:
+
+```bash
+poetry install
+poetry shell
+```
+
+5. Запустите бота:
+
+```bash
+poetry run python -m telegram_legal_bot.main
+```
+
+## Переменные окружения
+
+| Переменная              | Описание                                           |
+|-------------------------|----------------------------------------------------|
+| `TELEGRAM_BOT_TOKEN`    | Токен Telegram бота                                 |
+| `OPENAI_API_KEY`        | API-ключ OpenAI                                     |
+| `OPENAI_MODEL`          | Идентификатор модели OpenAI (по умолчанию `gpt-5`)  |
+| `MAX_REQUESTS_PER_HOUR` | Максимум запросов в час на пользователя (дефолт 10) |
+
+## Ограничения и безопасность
+
+- Бот не хранит персональные данные пользователей.
+- Встроенный rate-limiter предотвращает злоупотребления.
+- Ответы носят информационный характер и не являются юридической услугой.
+
+## Генерация `requirements.txt`
+
+Проект использует только Poetry. При необходимости создайте файл зависимостей для деплоя:
+
+```bash
+poetry export -f requirements.txt --output requirements.txt --without-hashes
+```
+
+## Graceful Shutdown
+
+Бот корректно завершается по сигналам `SIGINT`/`SIGTERM`, освобождая ресурсы и останавливая polling.
+
+## Логирование
+
+Логи пишутся в stdout с уровнем `INFO`. При необходимости измените конфигурацию в `telegram_legal_bot/main.py`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "telegram-legal-bot"
+version = "0.1.0"
+description = "Telegram bot for legal consultations powered by OpenAI GPT"
+authors = ["Your Name <you@example.com>"]
+readme = "README.md"
+packages = [{ include = "telegram_legal_bot" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+python-telegram-bot = "^21.1"
+openai = "^1.30"
+python-dotenv = "^1.0"
+
+[tool.poetry.group.dev.dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Сгенерировано через Poetry. При необходимости обновите командой:
+# poetry export -f requirements.txt --output requirements.txt --without-hashes
+python-telegram-bot>=21.1,<22.0
+openai>=1.30,<2.0
+python-dotenv>=1.0,<2.0

--- a/telegram_legal_bot/.env.example
+++ b/telegram_legal_bot/.env.example
@@ -1,0 +1,4 @@
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_MODEL=gpt-5
+MAX_REQUESTS_PER_HOUR=10

--- a/telegram_legal_bot/config.py
+++ b/telegram_legal_bot/config.py
@@ -1,0 +1,81 @@
+"""Модуль конфигурации бота."""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class OpenAISettings:
+    """Настройки доступа к OpenAI API."""
+
+    api_key: str
+    model: str
+    temperature: float = 0.3
+    max_tokens: int = 1500
+    system_prompt: str = (
+        "Ты - квалифицированный юрист-консультант. Отвечай на юридические вопросы "
+        "четко и структурированно. Всегда указывай применимые нормы права. "
+        "Предупреждай, что консультация носит информационный характер и не заменяет "
+        "профессиональную юридическую помощь. Отвечай в формате JSON с ключами: "
+        "summary (краткий ответ), details (подробное разъяснение), laws (список ссылок на законы)."
+    )
+
+
+@dataclass(slots=True)
+class BotSettings:
+    """Настройки телеграм-бота."""
+
+    token: str
+    max_requests_per_hour: int = 10
+    min_question_length: int = 20
+
+
+@dataclass(slots=True)
+class Settings:
+    """Объединённая конфигурация приложения."""
+
+    bot: BotSettings
+    openai: OpenAISettings
+
+
+def load_settings(env_file: Optional[str] = None) -> Settings:
+    """Загружает настройки из переменных окружения."""
+
+    if env_file:
+        load_dotenv(env_file)
+    else:
+        load_dotenv()
+
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    api_key = os.getenv("OPENAI_API_KEY")
+    model = os.getenv("OPENAI_MODEL", "gpt-5")
+    max_requests_raw = os.getenv("MAX_REQUESTS_PER_HOUR", "10")
+
+    if not token:
+        logger.error("Переменная TELEGRAM_BOT_TOKEN не найдена")
+        raise ValueError("Необходимо указать TELEGRAM_BOT_TOKEN в переменных окружения")
+
+    if not api_key:
+        logger.error("Переменная OPENAI_API_KEY не найдена")
+        raise ValueError("Необходимо указать OPENAI_API_KEY в переменных окружения")
+
+    try:
+        max_requests = int(max_requests_raw)
+    except ValueError as exc:  # pragma: no cover - защитный код
+        logger.warning(
+            "Некорректное значение MAX_REQUESTS_PER_HOUR=%s, используется значение по умолчанию", max_requests_raw
+        )
+        raise ValueError("MAX_REQUESTS_PER_HOUR должно быть целым числом") from exc
+
+    bot_settings = BotSettings(token=token, max_requests_per_hour=max_requests)
+    openai_settings = OpenAISettings(api_key=api_key, model=model)
+
+    logger.debug("Настройки успешно загружены")
+    return Settings(bot=bot_settings, openai=openai_settings)

--- a/telegram_legal_bot/handlers/__init__.py
+++ b/telegram_legal_bot/handlers/__init__.py
@@ -1,0 +1,6 @@
+"""Пакет обработчиков Telegram-бота."""
+
+from telegram_legal_bot.handlers.legal_query import LegalQueryHandler
+from telegram_legal_bot.handlers.start import help_command, start
+
+__all__ = ["LegalQueryHandler", "help_command", "start"]

--- a/telegram_legal_bot/handlers/legal_query.py
+++ b/telegram_legal_bot/handlers/legal_query.py
@@ -1,0 +1,112 @@
+"""Обработчик юридических запросов."""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+from telegram import Update
+from telegram.constants import ChatAction, ParseMode
+from telegram.ext import ContextTypes
+
+from telegram_legal_bot.config import Settings
+from telegram_legal_bot.services.openai_service import LegalAdvice, OpenAIService
+from telegram_legal_bot.utils.message_formatter import format_legal_response
+from telegram_legal_bot.utils.rate_limiter import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+
+class LegalQueryHandler:
+    """Инкапсулирует обработку юридических запросов."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+        self._openai_service = OpenAIService(settings.openai)
+        self._rate_limiter = RateLimiter(settings.bot.max_requests_per_hour, period_seconds=3600)
+        self._history: Dict[int, List[str]] = {}
+
+    async def handle(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Основной обработчик текстовых сообщений."""
+
+        if not update.effective_message or not update.effective_user:
+            return
+
+        user_id = update.effective_user.id
+        message_text = update.effective_message.text or ""
+
+        if not await self._validate_message(user_id, message_text, update, context):
+            return
+
+        await context.bot.send_chat_action(chat_id=update.effective_chat.id, action=ChatAction.TYPING)
+
+        try:
+            advice = await self._openai_service.generate_legal_advice(message_text)
+            await self._remember_history(user_id, message_text)
+            await self._send_response(update, advice)
+        except Exception:  # noqa: BLE001 - хотим логировать любую ошибку
+            logger.exception("Ошибка при обработке сообщения")
+            await update.effective_message.reply_text(
+                "⚠️ Произошла ошибка при получении консультации. Попробуйте повторить запрос позже."
+            )
+
+    async def _validate_message(
+        self,
+        user_id: int,
+        message_text: str,
+        update: Update,
+        context: ContextTypes.DEFAULT_TYPE,
+    ) -> bool:
+        """Проверяет корректность запроса."""
+
+        if not message_text.strip():
+            await update.effective_message.reply_text("Пожалуйста, отправьте текстовое сообщение с юридическим вопросом.")
+            return False
+
+        if len(message_text.strip()) < self._settings.bot.min_question_length:
+            await update.effective_message.reply_text(
+                "Опишите ситуацию подробнее, чтобы я смог предоставить качественную консультацию."
+            )
+            return False
+
+        if self._is_spam(message_text):
+            await update.effective_message.reply_text("Похоже на спам. Пожалуйста, сформулируйте юридический вопрос.")
+            return False
+
+        if not await self._rate_limiter.check(user_id):
+            remaining = await self._rate_limiter.remaining(user_id)
+            await update.effective_message.reply_text(
+                "⌛ Вы исчерпали лимит консультаций. Попробуйте снова позже. "
+                f"Остаток доступных запросов: {remaining}."
+            )
+            return False
+
+        if context.application is not None:
+            history = self._history.get(user_id)
+            if history:
+                logger.debug("История пользователя %s: %s", user_id, history[-3:])
+
+        return True
+
+    @staticmethod
+    def _is_spam(message_text: str) -> bool:
+        """Простейшая проверка на однообразный текст."""
+
+        stripped = message_text.strip()
+        if not stripped:
+            return True
+        unique_chars = {char for char in stripped.lower() if char.isalpha()}
+        return len(unique_chars) <= 2 and len(stripped) > 10
+
+    async def _remember_history(self, user_id: int, message_text: str) -> None:
+        """Сохраняет последние вопросы пользователя."""
+
+        history = self._history.setdefault(user_id, [])
+        history.append(message_text)
+        if len(history) > 5:
+            self._history[user_id] = history[-5:]
+
+    async def _send_response(self, update: Update, advice: LegalAdvice) -> None:
+        """Отправляет пользователю красиво оформленный ответ."""
+
+        formatted_message = format_legal_response(advice.summary, advice.details, advice.laws)
+        await update.effective_message.reply_text(formatted_message, parse_mode=ParseMode.MARKDOWN_V2)

--- a/telegram_legal_bot/handlers/start.py
+++ b/telegram_legal_bot/handlers/start.py
@@ -1,0 +1,38 @@
+"""Обработчики стартовых команд."""
+from __future__ import annotations
+
+from telegram import Update
+from telegram.constants import ParseMode
+from telegram.ext import ContextTypes
+
+WELCOME_MESSAGE = (
+    "⚖️ *Добро пожаловать в LegalBot!*\n\n"
+    "Я помогу вам получить *информационные юридические консультации*.\n"
+    "Отправьте мне вопрос, описав ситуацию максимально подробно.\n\n"
+    "_Как использовать:_\n"
+    "1. Сформулируйте вопрос и отправьте его в чат.\n"
+    "2. Подождите, пока я подготовлю ответ.\n"
+    "3. Ознакомьтесь с консультацией и при необходимости уточните детали._\n\n"
+    "Используйте /help, чтобы узнать о дополнительных возможностях."
+)
+
+HELP_MESSAGE = (
+    "ℹ️ *Справка по LegalBot*\n\n"
+    "• Задавайте юридические вопросы текстом.\n"
+    "• Я предоставляю краткий вывод, подробное разъяснение и применимые нормы права.\n"
+    "• Ограничение: не более 10 запросов в час на пользователя (по умолчанию).\n"
+    "• Пожалуйста, не отправляйте персональные данные.\n"
+    "• Консультация носит информационный характер и не заменяет работу юриста."
+)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Отправляет приветственное сообщение."""
+
+    await update.effective_message.reply_text(WELCOME_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2)
+
+
+async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Отправляет справочную информацию."""
+
+    await update.effective_message.reply_text(HELP_MESSAGE, parse_mode=ParseMode.MARKDOWN_V2)

--- a/telegram_legal_bot/main.py
+++ b/telegram_legal_bot/main.py
@@ -1,0 +1,83 @@
+"""Точка входа в приложение Telegram Legal Bot."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+from typing import Any
+
+from telegram import Update
+from telegram.ext import Application, CommandHandler, MessageHandler, filters
+
+from telegram_legal_bot.config import Settings, load_settings
+from telegram_legal_bot.handlers.legal_query import LegalQueryHandler
+from telegram_legal_bot.handlers.start import help_command, start
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+async def _error_handler(update: object, context: Any) -> None:
+    """Глобальный обработчик ошибок бота."""
+
+    logger.exception("Произошла ошибка при обработке update=%s", update)
+
+
+async def _run_application(settings: Settings) -> None:
+    """Запускает приложение и обрабатывает graceful shutdown."""
+
+    application = (
+        Application.builder()
+        .token(settings.bot.token)
+        .parse_mode("MarkdownV2")
+        .post_init(lambda app: logger.info("Бот инициализирован"))
+        .build()
+    )
+
+    legal_query_handler = LegalQueryHandler(settings)
+
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(CommandHandler("help", help_command))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, legal_query_handler.handle))
+    application.add_error_handler(_error_handler)
+
+    stop_event = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, stop_event.set)
+        except NotImplementedError:  # pragma: no cover - Windows compatibility
+            signal.signal(sig, lambda *_: stop_event.set())
+
+    await application.initialize()
+    await application.start()
+    await application.updater.start_polling(allowed_updates=Update.ALL_TYPES)
+    logger.info("LegalBot запущен и ожидает сообщения")
+
+    await stop_event.wait()
+
+    logger.info("Остановка бота...")
+    await application.updater.stop()
+    await application.stop()
+    await application.shutdown()
+    logger.info("Бот остановлен корректно")
+
+
+def main() -> None:
+    """Инициализирует настройки и запускает бота."""
+
+    try:
+        settings = load_settings()
+    except ValueError as exc:
+        logger.error("Не удалось загрузить настройки: %s", exc)
+        raise
+
+    asyncio.run(_run_application(settings))
+
+
+if __name__ == "__main__":
+    main()

--- a/telegram_legal_bot/services/__init__.py
+++ b/telegram_legal_bot/services/__init__.py
@@ -1,0 +1,5 @@
+"""Сервисы интеграции."""
+
+from telegram_legal_bot.services.openai_service import LegalAdvice, OpenAIService
+
+__all__ = ["LegalAdvice", "OpenAIService"]

--- a/telegram_legal_bot/services/openai_service.py
+++ b/telegram_legal_bot/services/openai_service.py
@@ -1,0 +1,104 @@
+"""Сервис взаимодействия с OpenAI API."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - импорт зависит от версии SDK
+    from openai import AsyncOpenAI, OpenAIError
+except ImportError:  # pragma: no cover - совместимость с будущими версиями
+    from openai import AsyncOpenAI  # type: ignore[assignment]
+    from openai import APIError as OpenAIError  # type: ignore
+
+from telegram_legal_bot.config import OpenAISettings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class LegalAdvice:
+    """Структурированный ответ модели."""
+
+    summary: str
+    details: str
+    laws: List[str]
+
+
+class OpenAIService:
+    """Инкапсулирует логику работы с OpenAI GPT."""
+
+    def __init__(self, settings: OpenAISettings) -> None:
+        self._settings = settings
+        self._client = AsyncOpenAI(api_key=settings.api_key)
+
+    async def generate_legal_advice(self, query: str) -> LegalAdvice:
+        """Возвращает структурированный ответ на юридический вопрос."""
+
+        logger.debug("Отправка запроса в OpenAI: %s", query)
+        try:
+            response = await self._client.responses.create(
+                model=self._settings.model,
+                temperature=self._settings.temperature,
+                max_output_tokens=self._settings.max_tokens,
+                response_format={"type": "json_object"},
+                input=[
+                    {"role": "system", "content": self._settings.system_prompt},
+                    {"role": "user", "content": query},
+                ],
+            )
+        except OpenAIError as exc:
+            logger.exception("Ошибка OpenAI API")
+            raise exc
+
+        content = self._extract_text(response)
+        logger.debug("Ответ OpenAI: %s", content)
+
+        data = self._parse_response(content)
+        return LegalAdvice(
+            summary=data.get("summary", "Не удалось сформировать краткий ответ."),
+            details=data.get("details", "Попробуйте задать вопрос иначе."),
+            laws=data.get("laws", []),
+        )
+
+    @staticmethod
+    def _parse_response(content: str) -> Dict[str, Any]:
+        """Преобразует ответ модели в словарь."""
+
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            logger.warning("Не удалось распарсить JSON. Возвращаем ответ в текстовом виде.")
+            return {
+                "summary": content.strip(),
+                "details": content.strip(),
+                "laws": [],
+            }
+
+    @staticmethod
+    def _extract_text(response: Any) -> str:
+        """Извлекает текст из ответа Responses API."""
+
+        output_text = getattr(response, "output_text", None)
+        if output_text:
+            return output_text
+
+        parts: List[str] = []
+        output_blocks = getattr(response, "output", None)
+        if not output_blocks:
+            return ""
+
+        for block in output_blocks:
+            block_content = getattr(block, "content", None) or []
+            for item in block_content:
+                text_piece: str | None = None
+                if isinstance(item, dict):
+                    text_piece = item.get("text")
+                else:
+                    text_piece = getattr(item, "text", None)
+
+                if text_piece:
+                    parts.append(text_piece)
+
+        return "".join(parts)

--- a/telegram_legal_bot/utils/__init__.py
+++ b/telegram_legal_bot/utils/__init__.py
@@ -1,0 +1,6 @@
+"""Утилитарные функции и классы бота."""
+
+from telegram_legal_bot.utils.message_formatter import format_legal_response
+from telegram_legal_bot.utils.rate_limiter import RateLimiter
+
+__all__ = ["RateLimiter", "format_legal_response"]

--- a/telegram_legal_bot/utils/message_formatter.py
+++ b/telegram_legal_bot/utils/message_formatter.py
@@ -1,0 +1,33 @@
+"""Форматирование ответов для Telegram."""
+from __future__ import annotations
+
+from typing import Iterable
+
+from telegram.helpers import escape_markdown
+
+
+def format_laws(laws: Iterable[str]) -> str:
+    """Форматирует список законов в моноширинном стиле."""
+
+    escaped_laws = [f"`{escape_markdown(law, version=2)}`" for law in laws if law]
+    return "\n".join(escaped_laws) if escaped_laws else "`Нормы права не найдены.`"
+
+
+def format_legal_response(summary: str, details: str, laws: Iterable[str]) -> str:
+    """Возвращает красиво отформатированный ответ."""
+
+    summary = escape_markdown(summary, version=2)
+    details = escape_markdown(details, version=2)
+    laws_block = format_laws(laws)
+
+    return (
+        "⚖️ *ЮРИДИЧЕСКАЯ КОНСУЛЬТАЦИЯ*\n\n"
+        "📋 *Краткий ответ:*\n"
+        f"{summary}\n\n"
+        "📄 *Подробное разъяснение:*\n"
+        f"{details}\n\n"
+        "📚 *Применимые нормы права:*\n"
+        f"{laws_block}\n\n"
+        "⚠️ *Важно:*\n"
+        "Данная консультация носит информационный характер и не заменяет профессиональную юридическую помощь."
+    )

--- a/telegram_legal_bot/utils/rate_limiter.py
+++ b/telegram_legal_bot/utils/rate_limiter.py
@@ -1,0 +1,43 @@
+"""Простейший лимитер запросов."""
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import defaultdict, deque
+from typing import Deque, Dict
+
+
+class RateLimiter:
+    """Ограничивает количество запросов за указанный период."""
+
+    def __init__(self, max_calls: int, period_seconds: int) -> None:
+        self._max_calls = max_calls
+        self._period = period_seconds
+        self._calls: Dict[int, Deque[float]] = defaultdict(deque)
+        self._lock = asyncio.Lock()
+
+    async def check(self, key: int) -> bool:
+        """Проверяет, может ли пользователь выполнить ещё один запрос."""
+
+        async with self._lock:
+            now = time.monotonic()
+            calls = self._calls[key]
+
+            while calls and now - calls[0] > self._period:
+                calls.popleft()
+
+            if len(calls) >= self._max_calls:
+                return False
+
+            calls.append(now)
+            return True
+
+    async def remaining(self, key: int) -> int:
+        """Возвращает оставшееся количество запросов."""
+
+        async with self._lock:
+            now = time.monotonic()
+            calls = self._calls[key]
+            while calls and now - calls[0] > self._period:
+                calls.popleft()
+            return max(self._max_calls - len(calls), 0)


### PR DESCRIPTION
## Summary
- switch the OpenAI integration to the Responses API and add a helper to extract JSON output
- default configuration and documentation to the gpt-5 model and bump the SDK requirement

## Testing
- poetry check
- python -m compileall telegram_legal_bot

------
https://chatgpt.com/codex/tasks/task_e_68cc17712e08832d9bd317e873fa5bb7